### PR TITLE
adding callbacks and named transitions

### DIFF
--- a/lib/res/callbacks.ex
+++ b/lib/res/callbacks.ex
@@ -1,0 +1,21 @@
+defmodule Res.Callbacks do
+  require Logger
+
+  def testEnter do
+    Logger.info("Entered")
+  end
+
+  def testLeave do
+    Logger.info("Left")
+  end
+
+  def run(callbacks) when is_list(callbacks) do
+    Enum.each(callbacks, &Res.Callbacks.apply_callback/1)
+  end
+
+  def run(_), do: nil
+
+  def apply_callback(callback) do
+    apply(__MODULE__, String.to_existing_atom(callback), [])
+  end
+end

--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+.PHONY: build
+build:
+	docker run --rm -it -v ${PWD}:/app -w /app elixir mix deps.get
+
+.PHONY: test
+test:
+	docker run --rm -it -v ${PWD}:/app -w /app elixir mix test
+
+.PHONY: format
+format:
+	docker run --rm -it -v ${PWD}:/app -w /app elixir mix format 
+
+.PHONY: iex
+iex:
+	docker run --rm -it -v ${PWD}:/app -w /app elixir iex -S mix

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,8 @@ defmodule Res.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.18.1"},
-      {:poison, "~> 4.0"}
+      {:ex_doc, "~> 0.23.0"},
+      {:jason, "~> 1.2"}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.13", "2c6ce9768fc9fdbf4046f457e207df6360ee6c91ee1ecb8e9a139f96a4289d91", [:mix], [{:earmark_parser, ">= 1.4.12", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "a0cf3ed88ef2b1964df408889b5ecb886d1a048edde53497fc935ccd15af3403"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
 }

--- a/priv/test.json
+++ b/priv/test.json
@@ -9,9 +9,14 @@
       "on_enter": ["testEnter"]
     }
   },
-  "transitions": {
+  "valid_transitions": {
     "open": "reserved",
     "reserved": ["in use", "open"],
     "in use": "open"
+  },
+  "named_transitions" : {
+    "claim": {
+      "to": "in use"
+    }
   }
 }

--- a/priv/test.json
+++ b/priv/test.json
@@ -1,6 +1,14 @@
 {
   "initial_state": "open",
-  "states": ["open", "reserved", "in use"],
+  "states": {
+    "open": null,
+    "reserved": {
+      "on_leave": ["testLeave"] 
+    },
+    "in use": {
+      "on_enter": ["testEnter"]
+    }
+  },
   "transitions": {
     "open": "reserved",
     "reserved": ["in use", "open"],

--- a/test/res/machine_test.exs
+++ b/test/res/machine_test.exs
@@ -31,4 +31,19 @@ defmodule Res.MachineTest do
       {:ok, _} = Res.Machine.transition(state, machine, "in use")
     end) =~ "Entered"
   end
+
+  test "handles named transitions" do
+    machine = Res.Machine.parse("priv/test.json")
+    state = Res.Machine.init(machine)
+    {:ok, state} = Res.Machine.transition(state, machine, "reserved")
+    {:ok, state} = Res.Machine.transition(state, machine, "claim")
+
+    assert state.current_state == "in use"
+  end
+
+  test "named transitions must observe valid transitions" do
+    machine = Res.Machine.parse("priv/test.json")
+    state = Res.Machine.init(machine)
+    assert {:error, _} = Res.Machine.transition(state, machine, "claim")
+  end
 end

--- a/test/res/machine_test.exs
+++ b/test/res/machine_test.exs
@@ -1,5 +1,34 @@
 defmodule Res.MachineTest do
   # There are no tests here because we use the documentation to build the tests for Machine
   use ExUnit.Case
+  import ExUnit.CaptureLog
   doctest Res.Machine
+
+  test "it doesnt run calllbacks if they are not configured" do
+    machine = Res.Machine.parse("priv/test.json")
+    state = Res.Machine.init(machine)
+    assert capture_log([level: :info], fn ->
+      {:ok, _} = Res.Machine.transition(state, machine, "reserved")
+    end) == ""
+  end
+
+  test "runs on_leave calllbacks" do
+    machine = Res.Machine.parse("priv/test.json")
+    state = Res.Machine.init(machine)
+    {:ok, state} = Res.Machine.transition(state, machine, "reserved")
+
+    assert capture_log([level: :info], fn ->
+      {:ok, _} = Res.Machine.transition(state, machine, "in use")
+    end) =~ "Left"
+  end
+
+  test "runs on_enter calllbacks" do
+    machine = Res.Machine.parse("priv/test.json")
+    state = Res.Machine.init(machine)
+    {:ok, state} = Res.Machine.transition(state, machine, "reserved")
+
+    assert capture_log([level: :info], fn ->
+      {:ok, _} = Res.Machine.transition(state, machine, "in use")
+    end) =~ "Entered"
+  end
 end


### PR DESCRIPTION
Lets talk about how to make callback functions more pluggable. Right now I have a callbacks module where you can add callbacks. This should probably be a client side module. I am thinking it is easy enough to add the callback module to the config and replace __MODULE__ in apply. Let me know what you think.